### PR TITLE
feat(learn-to-play): add djembe starter songbook

### DIFF
--- a/learn-to-play/00-INDEX.md
+++ b/learn-to-play/00-INDEX.md
@@ -1,0 +1,28 @@
+# Djembe — Starter Songbook
+
+The djembe is a West African goblet drum played with bare hands.
+Its three fundamental tones form the core vocabulary for all patterns.
+
+## Difficulty key
+- ★☆☆ — Beginner: single voice, slow tempo
+- ★★☆ — Intermediate: two voices, call-and-response
+- ★★★ — Advanced: polyrhythm, ensemble interlocking
+
+## Stroke notation
+| Symbol | Stroke | Technique |
+|--------|--------|-----------|
+| **B** | Bass   | Full hand at center, all fingers together, low boom |
+| **T** | Tone   | Four fingers at rim, clear mid-range ring |
+| **S** | Slap   | Cupped hand at rim, dry crack, fingers separate on rebound |
+| **-** | Rest   | Silence / ghost beat |
+
+## Tunes in this songbook
+1. `tunes/basic-pulse/` ★☆☆ — Three-tone introduction
+2. `tunes/kuku/` ★★☆ — Traditional Kuku rhythm (Guinea)
+3. `tunes/fanga/` ★★☆ — Traditional Fanga welcome rhythm (Guinea)
+4. `tunes/kassa/` ★★★ — Traditional Kassa harvest rhythm (Guinea)
+5. `tunes/djole/` ★★★ — Traditional Djole youth rhythm (Guinea)
+
+## Note on tradition
+These rhythms are traditional community property of West African peoples, primarily from Guinea,
+Mali, and Senegal. They are public domain. Learn them with respect for their cultural context.

--- a/learn-to-play/fingerings/chart.md
+++ b/learn-to-play/fingerings/chart.md
@@ -1,0 +1,28 @@
+# Djembe Stroke Reference
+
+```
+       ╭───────────────────╮
+       │   PLAYING HEAD    │
+       │                   │
+       │  ╭─────────────╮  │
+       │  │  B = BASS   │  │  ← Full palm, center
+       │  │  (center)   │  │
+       │  ╰─────────────╯  │
+       │                   │
+  T/S →│ ═══ RIM ZONE ═══ │← T/S
+       │                   │
+       ╰───────────────────╯
+              │   │
+           GOBLET BODY
+```
+
+| Stroke | Hand Position | Sound Target |
+|--------|--------------|--------------|
+| **B** Bass | Full palm flat at center, all fingers relaxed | Deep boom, 60–100 Hz |
+| **T** Tone | 4 fingers at rim, straight, relax after strike | Clean ring, mid-frequency |
+| **S** Slap | Cupped hand at rim, fingers separate instantly | Dry crack, high frequency |
+
+## Tips
+- Bass: let the hand bounce off naturally — don't push in.
+- Tone: strike with the first knuckle joint of 4 fingers.
+- Slap: the cup collapses on impact; that's what makes the crack.

--- a/learn-to-play/scales/warmup.md
+++ b/learn-to-play/scales/warmup.md
@@ -1,0 +1,20 @@
+# Djembe Warm-Up: Three-Tone Exercise
+
+Practice each tone in isolation before combining. 60 BPM, one stroke per quarter beat.
+
+```
+Bass only (8 bars):
+| B - B - | B - B - | B - B - | B - B - |
+
+Tone only (8 bars):
+| - T - T | - T - T | - T - T | - T - T |
+
+Slap only (8 bars):
+| S - - - | S - - - | S - - - | S - - - |
+
+All three in sequence (8 bars):
+| B T S - | B T S - | B T S - | B T S - |
+```
+
+**Tip:** The three tones should sound distinctly different. If bass and tone sound similar,
+adjust hand position — bass needs more palm surface, tone needs more finger rim contact.

--- a/learn-to-play/tunes/basic-pulse/patterns.md
+++ b/learn-to-play/tunes/basic-pulse/patterns.md
@@ -1,0 +1,18 @@
+# Basic Pulse ★☆☆
+
+A foundational pattern to build three-tone independence. 4/4 time.
+
+```
+Beat:  1  +  2  +  3  +  4  +
+       B  -  T  -  S  -  T  -
+```
+
+Variation with double bass:
+```
+Beat:  1  +  2  +  3  +  4  +
+       B  B  T  -  S  -  T  -
+```
+
+**Form:** 8-bar loop. Tempo: 70 BPM. Repeat until tones are clean and distinct.
+
+**Practice tip:** Record yourself and listen back. The bass should be the deepest, the slap the brightest.

--- a/learn-to-play/tunes/basic-pulse/songsheet.md
+++ b/learn-to-play/tunes/basic-pulse/songsheet.md
@@ -1,0 +1,14 @@
+# Basic Pulse — Songsheet
+
+**Tempo:** 70–100 BPM  **Meter:** 4/4  **Difficulty:** ★☆☆
+
+## Pattern
+```
+1  +  2  +  3  +  4  +
+B  -  T  -  S  -  T  -
+```
+
+## Structure
+- Bars 1–8:   Basic pattern
+- Bars 9–16:  Double-bass variation
+- Bars 17–24: Original pattern

--- a/learn-to-play/tunes/djole/patterns.md
+++ b/learn-to-play/tunes/djole/patterns.md
@@ -1,0 +1,21 @@
+# Djole ★★★
+
+Traditional youth and celebration rhythm from the Sosso people of Guinea.
+Energetic and fast; typically played at coming-of-age ceremonies.
+
+```
+Djembe (16th-note grid, one bar):
+Beat:  1  e  +  a  2  e  +  a  3  e  +  a  4  e  +  a
+       S  -  T  T  -  S  -  T  S  -  T  -  B  B  -  S
+```
+
+Breakdown (learn in two halves):
+```
+Half 1: S - T T - S - T
+Half 2: S - T - B B - S
+```
+
+**Form:** 16-bar repeating loop. Tempo: 120–140 BPM.
+**Source:** Traditional Djole rhythm, Sosso people, Guinea (public domain).
+
+**Practice tip:** Learn each half slowly, then join at half speed before bringing up to full tempo.

--- a/learn-to-play/tunes/djole/songsheet.md
+++ b/learn-to-play/tunes/djole/songsheet.md
@@ -1,0 +1,16 @@
+# Djole — Songsheet
+
+**Tempo:** 130 BPM  **Meter:** 4/4  **Difficulty:** ★★★  
+**Tradition:** Sosso youth rhythm, Guinea (public domain)
+
+## Full pattern (16th-note grid)
+```
+1  e  +  a  2  e  +  a  3  e  +  a  4  e  +  a
+S  -  T  T  -  S  -  T  S  -  T  -  B  B  -  S
+```
+
+## Song structure
+- Bars 1–4:   Half 1 only (learn)
+- Bars 5–8:   Half 2 only (learn)
+- Bars 9–12:  Full pattern slow (80 BPM)
+- Bars 13–16: Full pattern at tempo (130 BPM)

--- a/learn-to-play/tunes/djole/songsheet.md
+++ b/learn-to-play/tunes/djole/songsheet.md
@@ -1,6 +1,6 @@
 # Djole — Songsheet
 
-**Tempo:** 130 BPM  **Meter:** 4/4  **Difficulty:** ★★★  
+**Tempo:** 130 BPM  **Meter:** 4/4  **Difficulty:** ★★★
 **Tradition:** Sosso youth rhythm, Guinea (public domain)
 
 ## Full pattern (16th-note grid)

--- a/learn-to-play/tunes/fanga/patterns.md
+++ b/learn-to-play/tunes/fanga/patterns.md
@@ -1,0 +1,19 @@
+# Fanga ★★☆
+
+Traditional welcome and peace rhythm from Guinea/Liberia.
+Often played to greet honored guests. 4/4, straightforward and dignified.
+
+```
+Djembe lead (one bar):
+Beat:  1  e  +  a  2  e  +  a  3  e  +  a  4  e  +  a
+       S  -  T  -  S  -  T  -  B  -  B  -  S  -  T  -
+```
+
+Simplified (beginner) version:
+```
+Beat:  1  +  2  +  3  +  4  +
+       S  T  S  T  B  B  S  T
+```
+
+**Form:** 8-bar loop. Tempo: 80 BPM.
+**Source:** Traditional Fanga rhythm, Guinea/Liberia (public domain).

--- a/learn-to-play/tunes/fanga/songsheet.md
+++ b/learn-to-play/tunes/fanga/songsheet.md
@@ -1,0 +1,16 @@
+# Fanga — Songsheet
+
+**Tempo:** 80 BPM  **Meter:** 4/4  **Difficulty:** ★★☆  
+**Tradition:** Guinea/Liberia welcome rhythm (public domain)
+
+## Beginner pattern
+```
+1  +  2  +  3  +  4  +
+S  T  S  T  B  B  S  T
+```
+
+## Advanced (16th-note) pattern
+```
+1  e  +  a  2  e  +  a  3  e  +  a  4  e  +  a
+S  -  T  -  S  -  T  -  B  -  B  -  S  -  T  -
+```

--- a/learn-to-play/tunes/fanga/songsheet.md
+++ b/learn-to-play/tunes/fanga/songsheet.md
@@ -1,6 +1,6 @@
 # Fanga — Songsheet
 
-**Tempo:** 80 BPM  **Meter:** 4/4  **Difficulty:** ★★☆  
+**Tempo:** 80 BPM  **Meter:** 4/4  **Difficulty:** ★★☆
 **Tradition:** Guinea/Liberia welcome rhythm (public domain)
 
 ## Beginner pattern

--- a/learn-to-play/tunes/kassa/patterns.md
+++ b/learn-to-play/tunes/kassa/patterns.md
@@ -1,0 +1,23 @@
+# Kassa ★★★
+
+Traditional harvest and agricultural rhythm from Mandinka regions of Guinea.
+Faster tempo, driving feel. Uses call-and-response between djembe voices.
+
+```
+Djembe 1 (call, one bar of 12/8):
+1  2  3  4  5  6  7  8  9  10 11 12
+S  -  S  -  T  -  S  -  B  -  B  -
+
+Djembe 2 (response, same bar):
+1  2  3  4  5  6  7  8  9  10 11 12
+-  T  -  T  -  S  -  T  -  S  -  T
+```
+
+Solo djembe version (combine both voices):
+```
+1  2  3  4  5  6  7  8  9  10 11 12
+S  T  S  T  T  S  S  T  B  S  B  T
+```
+
+**Form:** 16-bar loop. Tempo: 100–120 BPM.
+**Source:** Traditional Kassa rhythm, Guinea (public domain).

--- a/learn-to-play/tunes/kassa/songsheet.md
+++ b/learn-to-play/tunes/kassa/songsheet.md
@@ -1,0 +1,20 @@
+# Kassa — Songsheet
+
+**Tempo:** 110 BPM  **Meter:** 12/8  **Difficulty:** ★★★  
+**Tradition:** Mandinka harvest rhythm, Guinea (public domain)
+
+## Solo pattern (12 positions)
+```
+1  2  3  4  5  6  7  8  9  10 11 12
+S  T  S  T  T  S  S  T  B  S  B  T
+```
+
+## Ensemble: Call (Djembe 1)
+```
+S  -  S  -  T  -  S  -  B  -  B  -
+```
+
+## Ensemble: Response (Djembe 2)
+```
+-  T  -  T  -  S  -  T  -  S  -  T
+```

--- a/learn-to-play/tunes/kassa/songsheet.md
+++ b/learn-to-play/tunes/kassa/songsheet.md
@@ -1,6 +1,6 @@
 # Kassa — Songsheet
 
-**Tempo:** 110 BPM  **Meter:** 12/8  **Difficulty:** ★★★  
+**Tempo:** 110 BPM  **Meter:** 12/8  **Difficulty:** ★★★
 **Tradition:** Mandinka harvest rhythm, Guinea (public domain)
 
 ## Solo pattern (12 positions)

--- a/learn-to-play/tunes/kuku/patterns.md
+++ b/learn-to-play/tunes/kuku/patterns.md
@@ -1,0 +1,21 @@
+# Kuku ★★☆
+
+Traditional rhythm from the forest region of Guinea (Basse Côte).
+Originally played for fishing and water ceremonies. 6/8 feel over two bars.
+
+```
+Bar 1 (6 eighth notes):
+| T  -  T  S  -  S |
+
+Bar 2:
+| T  -  T  B  -  B |
+```
+
+Full djembe part (12/8 — 12 eighth notes per pattern):
+```
+Position: 1  2  3  4  5  6  7  8  9  10 11 12
+Djembe:   T  -  T  S  -  S  T  -  T  B  -  B
+```
+
+**Form:** 16-bar loop. Tempo: 90 BPM.
+**Source:** Traditional Kuku rhythm, Guinea (West Africa). Public domain.

--- a/learn-to-play/tunes/kuku/songsheet.md
+++ b/learn-to-play/tunes/kuku/songsheet.md
@@ -1,0 +1,14 @@
+# Kuku — Songsheet
+
+**Tempo:** 90 BPM  **Meter:** 12/8 (two bars of 6)  **Difficulty:** ★★☆  
+**Tradition:** Basse Côte, Guinea (public domain)
+
+## Pattern (12 positions)
+```
+1  2  3  4  5  6  7  8  9  10 11 12
+T  -  T  S  -  S  T  -  T  B  -  B
+```
+
+## Notes
+- Kuku is a joyful rhythm — keep the tone strokes bright and open.
+- The bass tones in positions 10-12 provide grounding after the high slaps.

--- a/learn-to-play/tunes/kuku/songsheet.md
+++ b/learn-to-play/tunes/kuku/songsheet.md
@@ -1,6 +1,6 @@
 # Kuku — Songsheet
 
-**Tempo:** 90 BPM  **Meter:** 12/8 (two bars of 6)  **Difficulty:** ★★☆  
+**Tempo:** 90 BPM  **Meter:** 12/8 (two bars of 6)  **Difficulty:** ★★☆
 **Tradition:** Basse Côte, Guinea (public domain)
 
 ## Pattern (12 positions)


### PR DESCRIPTION
## Summary

Adds a `learn-to-play/` folder to the djembe repo with a 5-pattern/tune starter songbook.

- `00-INDEX.md` — songbook overview, difficulty key, stroke notation
- `scales/warmup.md` — stroke control and warm-up exercises
- `fingerings/chart.md` or `strike-patterns/chart.md` — reference chart
- `tunes/<slug>/patterns.md` — ASCII stroke patterns (B/S/T/H or B/T/S)
- `tunes/<slug>/songsheet.md` — full pattern with structure notes

All patterns use traditional public-domain rhythm traditions or original Heifer Zephyr material (MIT).

Refs #1

## Test plan
- [ ] Open `00-INDEX.md` and verify difficulty key and tune list are correct
- [ ] Play through each pattern at the listed tempo
- [ ] Verify stroke notation is consistent (B/S/T/H for cajon; B/T/S for djembe; tilt notation for rainstick)
- [ ] Confirm no copyrighted material (all patterns are traditional/PD or original)

🤖 Generated with [Claude Code](https://claude.com/claude-code)