### PR TITLE
wolfram-rename(djembe): unique starter naming + ref fixes

### DIFF
--- a/explorer.html
+++ b/explorer.html
@@ -360,6 +360,7 @@ mark.hit{background:var(--gold);color:var(--ink);
   </div>
   <div class="actions">
     <input id="search" class="search" placeholder="Search packet content…" aria-label="Search packet content">
+    <a class="action-btn" href="../instrument-showcase/site/library.html" title="Browse all studio explorers">← Library</a>
     <a class="action-btn" href="https://github.com/tonykoop/djembe" target="_blank" rel="noopener">GitHub</a>
   </div>
 </header>


### PR DESCRIPTION
Rename wolfram-starter.wl -> {slug}-starter.wl, remove identical dups, fix references (README/design/explorer). Aligns with Wolfram Cloud naming scheme. Refs instrument-maker#184