### PR TITLE
feat(v5): explorer V5 upgrade + build-packet gaps — djembe

### DIFF
--- a/assembly-manual.md
+++ b/assembly-manual.md
@@ -1,0 +1,40 @@
+# Assembly Manual — Djembe — Stave-Built Goblet Drum
+
+> **Status: placeholder** — expand with measured dimensions and shop-verified
+> steps after the first prototype build. All steps below are design-intent only.
+
+## Prerequisites
+
+- All parts cut and finished per `cut-list.csv`.
+- Materials sourced per `sourcing.csv`; key lead items received.
+- Jigs and fixtures ready per drawing brief.
+
+## Assembly Sequence
+
+### 1 · Shell Construction
+- [ ] Mark stave miter angles per cut list.
+- [ ] Dry-fit all staves; check roundness and gap.
+- [ ] Glue and clamp in segments; allow full cure before removing clamps.
+- [ ] Sand bearing edge flat and smooth; target radius per design.md.
+
+### 2 · Hardware Fitting
+- [ ] Drill and fit tensioning hardware (lugs / hooks / rods).
+- [ ] Verify even spacing per drawing brief.
+- [ ] Thread cord or fit hardware; leave head-tension range per design.md.
+
+### 3 · Head Fitting
+- [ ] Soak or prepare head per manufacturer instructions (if natural skin).
+- [ ] Mount head and counter-hoop; hand-tighten evenly.
+- [ ] Set initial tension to design fundamental (see `validation.csv`).
+
+### 4 · Tuning and Validation
+- [ ] Measure fundamental frequency with a tuner.
+- [ ] Record measurement in `validation.csv` with tuner make, environment (°F / RH).
+- [ ] Adjust tension until within acceptance band.
+- [ ] Note any anomalies in `risks.md` or `validation-loop.csv`.
+
+## Notes
+
+- Glue: Titebond II or III for wood-to-wood; check pot life in shop conditions.
+- Bearing edge: consistent radius is critical for head seal and overtone clarity.
+- Mark the final tension setting (number of turns / lug position) for repeatability.

--- a/capstone-manifest.json
+++ b/capstone-manifest.json
@@ -73,6 +73,23 @@
     "next": "shop packet candidate after strike measurements and geometry authority gates",
     "not_yet": "build-ready family, L2 bench-validated, or empirically validated packet"
   },
+  "engineering": {
+    "authority_register": "visual-output-register.csv",
+    "validation_gates": "validation.csv",
+    "validation_loop": "validation-loop.csv",
+    "design_packet": "design.md",
+    "fem_analysis": "analysis/helmholtz-fem/",
+    "parametric_goblet": "CAD/djembe-body/parametric-goblet.csv",
+    "wolfram": [
+      {
+        "source_file": "wolfram/djembe-goblet-acoustics.wl",
+        "cloud_path": "pending",
+        "cloud_url": "pending",
+        "permission": "Public-Execute",
+        "kind": "acoustics-starter"
+      }
+    ]
+  },
   "notes": [
     "Existing FEM analysis is analysis evidence only, not physical drum validation.",
     "Existing photos and scans support provenance and documentation, not dimensional authority by themselves.",

--- a/cnc/setup-sheet.md
+++ b/cnc/setup-sheet.md
@@ -1,0 +1,39 @@
+# CNC Setup Sheet — Djembe — Stave-Built Goblet Drum
+
+> **Status: placeholder** — populate from design.md dimensions and update after
+> first successful machining run.
+
+## Machine
+
+- Machine: TBD (CNC router / laser / lathe)
+- Controller: TBD
+- Work envelope: TBD
+
+## Stock
+
+| Dimension | Value | Notes |
+|-----------|-------|-------|
+| Material  | TBD   |       |
+| Thickness | TBD   |       |
+| Width     | TBD   |       |
+| Length    | TBD   |       |
+
+## Datums
+
+- **A** — drum center axis (spindle center for lathe; work-origin X0Y0 for router).
+- **B** — front face / head side.
+
+## Operations
+
+| # | Operation | Tool | Speed | Feed | Depth | Notes |
+|---|-----------|------|-------|------|-------|-------|
+| 1 | Rough profile | TBD | TBD | TBD | TBD | |
+| 2 | Bearing-edge radius | TBD | TBD | TBD | TBD | Match design.md |
+| 3 | Finish pass | TBD | TBD | TBD | TBD | |
+
+## Release Checks
+
+- [ ] Datum offsets confirmed against physical stock.
+- [ ] Bearing-edge radius within ±0.5 mm of design.
+- [ ] Shell roundness within 1 mm TIR.
+- [ ] No tool marks on head seat.

--- a/cut-list.csv
+++ b/cut-list.csv
@@ -1,0 +1,4 @@
+part,material,qty,thickness_in,width_in,length_in,notes
+shell-stave,TBD hardwood,TBD,TBD,TBD,TBD,Cut miter angles per drawing brief
+bearing-edge-ring,TBD hardwood,1,TBD,TBD,TBD,Sand to radius per design.md
+base-ring,TBD hardwood,1,TBD,TBD,TBD,Optional depending on design

--- a/data/deliverables-export.json
+++ b/data/deliverables-export.json
@@ -1,0 +1,104 @@
+{
+  "version": "0.1",
+  "generated_at": "2026-06-21",
+  "source_repo": "tonykoop/djembe",
+  "notes": [
+    "V5 percussion export \u2014 artifacts reflect current repo state.",
+    "Authority labels follow instrument-maker v4.5 DXF-first visual authority guard.",
+    "Promote artifacts from derived_preview to fabrication only after reviewed DXF or measured build."
+  ],
+  "packets": [
+    {
+      "id": "djembe",
+      "display_name": "Djembe \u2014 Stave-Built Goblet Drum",
+      "family": "membranophone \u00b7 stave-built goblet drum",
+      "repo_path": ".",
+      "status_line": "Status: L1 bare-bones packet",
+      "readiness_label": "L1 bare-bones packet",
+      "summary": "Engineering documentation for a stave-built djembe \u2014 the West African goblet drum. Includes Helmholtz / Webster horn FEM analysis, segmented-construction study, and parametric goblet geometry CSV. Built at Morgan Drums (St. Paul, MN) 2010.",
+      "site_entry": "explorer.html",
+      "artifacts": [
+        {
+          "id": "README-md",
+          "kind": "README",
+          "label": "Packet README",
+          "path": "README.md",
+          "authority": "reference_only",
+          "preview_role": "packet_card",
+          "runtime_state": "not_applicable",
+          "notes": "Reader-facing summary and repo map."
+        },
+        {
+          "id": "design-md",
+          "kind": "design",
+          "label": "Design sheet",
+          "path": "design.md",
+          "authority": "fabrication",
+          "preview_role": "detail_link",
+          "runtime_state": "not_applicable",
+          "notes": "Governing acoustic model, parametric dimensions, and material assumptions."
+        },
+        {
+          "id": "bom-csv",
+          "kind": "bom",
+          "label": "Bill of materials",
+          "path": "bom.csv",
+          "authority": "fabrication",
+          "preview_role": "detail_link",
+          "runtime_state": "not_applicable",
+          "notes": "Part list with quantities, materials, and estimated cost."
+        },
+        {
+          "id": "validation-csv",
+          "kind": "validation",
+          "label": "Validation table",
+          "path": "validation.csv",
+          "authority": "reference_only",
+          "preview_role": "detail_link",
+          "runtime_state": "not_applicable",
+          "notes": "Predicted vs measured values; names remaining measurement gates."
+        },
+        {
+          "id": "risks-md",
+          "kind": "risks",
+          "label": "Risk register",
+          "path": "risks.md",
+          "authority": "reference_only",
+          "preview_role": "detail_link",
+          "runtime_state": "not_applicable",
+          "notes": "Acoustic, structural, ergonomic, supply, and fit/finish risks each with a verification test."
+        },
+        {
+          "id": "photo-shotlist-md",
+          "kind": "photo_shotlist",
+          "label": "Photo shot list",
+          "path": "photo-shotlist.md",
+          "authority": "reference_only",
+          "preview_role": "detail_link",
+          "runtime_state": "not_applicable",
+          "notes": "Required shots per build stage for build-log documentation."
+        },
+        {
+          "id": "visual-output-register-csv",
+          "kind": "visual_output_register",
+          "label": "Visual output register",
+          "path": "visual-output-register.csv",
+          "authority": "reference_only",
+          "preview_role": "detail_link",
+          "runtime_state": "not_applicable",
+          "notes": "Records which artifacts are previews versus controlling geometry."
+        },
+        {
+          "id": "wolfram-model",
+          "kind": "wolfram_model",
+          "label": "Wolfram model \u2014 djembe-goblet-acoustics.wl",
+          "path": "https://www.wolframcloud.com/obj/wrfcoin/Musical_Instruments/percussion/djembe/djembe-goblet-acoustics.wl",
+          "authority": "reference_only",
+          "preview_role": "runtime_note",
+          "runtime_state": "source_only",
+          "notes": "Acoustic physics source. Source-only \u2014 no executed runtime output claimed."
+        }
+      ]
+    }
+  ]
+}

--- a/drawing-brief.md
+++ b/drawing-brief.md
@@ -1,0 +1,33 @@
+# Drawing Brief — Djembe — Stave-Built Goblet Drum
+
+## Required Drawing Set
+
+- Plan view: outside diameter, inside diameter (if applicable), head seat, and center.
+- Cross-section: depth, wall thickness, and bearing-edge radius.
+- Shell development / stave layout: miter angle, rough and final dimensions.
+- Jig / fixture layout: clamp positions, stop blocks, forming diameter.
+- Tensioning / tuning hardware detail: lug spacing, cord path, or rod positions.
+
+## Datum Plan
+
+- **Datum A** — drum center plane (axial reference).
+- **Datum B** — bearing edge (front head seat).
+- **Datum C** — stave seam or shell seam reference.
+
+## Authority Note
+
+All drawings are **first-prototype estimates** until a physical build validates
+shell roundness, head fit, and tension response.  Promote a drawing from
+`derived_preview` to `fabrication` authority only after measured dimensions
+confirm the predicted geometry within acceptance tolerances.
+
+## View Checklist
+
+- [ ] Plan view (top-down, showing head area)
+- [ ] Elevation / side view (full height with bearing edge)
+- [ ] Cross-section (wall, bearing-edge radius, any internal profile)
+- [ ] Stave / segment layout (if stave-built)
+- [ ] Hardware detail (lugs, hooks, rods, or rope path)
+- [ ] Jig / fixture drawing (if custom tooling required)
+
+*See `visual-output-register.csv` for the authority status of each drawing file.*

--- a/explorer.html
+++ b/explorer.html
@@ -1,901 +1,169 @@
 <!doctype html>
 <html lang="en">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Djembe Bare-Bones Starter Packet</title>
-
-<!-- model-viewer web component (CDN). DRACO decoder is auto-loaded from
-     gstatic.com on first decode of a compressed .glb. -->
-<script type="module" src="https://ajax.googleapis.com/ajax/libs/model-viewer/3.5.0/model-viewer.min.js"></script>
-
-<style>
-/* ============================================================
-   Heifer Zephyr — design tokens
-   ============================================================ */
-:root{
-  --walnut:#3D2817; --cedar:#B98B47; --cream:#F8F4E9; --paper:#FFFFFF;
-  --lapis:#1E3A8A; --gold:#D4A017; --ink:#1F1A14; --muted:#6B5E4D;
-  --rule:#E0D6C5; --ok:#2E7D32; --warn:#C89220; --block:#A03A2A;
-  --pill-bg:#FCEFC6; --pill-border:#D4A017;
-  --code-bg:#F2EBDA; --hover:#EFE7D3;
-  --sb-w:260px; --bar-h:56px;
-  --serif:"Fraunces","Source Serif Pro","Iowan Old Style",Georgia,serif;
-  --ui:"Inter","Source Sans Pro","Helvetica Neue",Arial,sans-serif;
-  --mono:"JetBrains Mono",Menlo,Consolas,monospace;
-  --italic-serif:"Cormorant Garamond","EB Garamond",Georgia,serif;
-}
-
-/* ============================================================
-   Reset + base
-   ============================================================ */
-*,*::before,*::after{box-sizing:border-box}
-html,body{margin:0;padding:0;background:var(--cream);color:var(--ink);
-  font-family:var(--ui);font-size:15px;line-height:1.5;-webkit-font-smoothing:antialiased}
-a{color:var(--lapis);text-decoration:none}
-a:hover{text-decoration:underline}
-code{font-family:var(--mono);font-size:0.88em;background:var(--code-bg);
-  padding:1px 5px;border-radius:3px}
-pre{font-family:var(--mono);font-size:12px;background:var(--code-bg);
-  padding:12px 14px;border-radius:4px;overflow:auto;line-height:1.45;
-  border-left:3px solid var(--cedar)}
-
-/* ============================================================
-   App bar (sticky top)
-   ============================================================ */
-.app-bar{position:sticky;top:0;z-index:30;height:var(--bar-h);
-  background:var(--walnut);color:var(--cream);
-  border-bottom:3px solid var(--gold);
-  display:flex;align-items:center;gap:24px;padding:0 20px}
-.brand{display:flex;align-items:baseline;gap:14px;flex:0 0 auto}
-.wordmark em{font-family:var(--italic-serif);font-style:italic;
-  font-size:22px;color:var(--gold);letter-spacing:0.01em}
-.instrument{font-family:var(--serif);font-size:15px;color:var(--cream);
-  border-left:1px solid rgba(248,244,233,0.3);padding-left:14px}
-.actions{margin-left:auto;display:flex;align-items:center;gap:12px}
-.search{background:rgba(248,244,233,0.12);color:var(--cream);
-  border:1px solid rgba(248,244,233,0.25);border-radius:4px;
-  padding:7px 12px;font-family:var(--ui);font-size:13px;width:320px}
-.search::placeholder{color:rgba(248,244,233,0.55)}
-.search:focus{outline:none;border-color:var(--gold);background:rgba(248,244,233,0.18)}
-.action-btn{display:inline-block;font-family:var(--ui);font-size:12px;
-  letter-spacing:0.04em;text-transform:uppercase;
-  color:var(--cream);border:1px solid rgba(248,244,233,0.35);
-  border-radius:3px;padding:6px 10px}
-.action-btn:hover{background:rgba(248,244,233,0.12);text-decoration:none;color:var(--gold)}
-
-/* ============================================================
-   App layout (sidebar + main)
-   ============================================================ */
-.app{display:grid;grid-template-columns:var(--sb-w) 1fr;
-  min-height:calc(100vh - var(--bar-h))}
-.sidebar{background:var(--paper);border-right:1px solid var(--rule);
-  position:sticky;top:var(--bar-h);height:calc(100vh - var(--bar-h));
-  overflow-y:auto;padding:18px 0}
-.sidebar .label{font-family:var(--ui);font-size:11px;color:var(--muted);
-  text-transform:uppercase;letter-spacing:0.1em;padding:8px 22px 4px;
-  margin-top:8px}
-.sidebar .label:first-of-type{margin-top:0}
-.toc{list-style:none;margin:0;padding:0}
-.toc li{margin:0}
-.toc-label{font-family:var(--ui);font-size:11px;color:var(--muted);
-  text-transform:uppercase;letter-spacing:0.1em;padding:8px 22px 4px;
-  margin-top:8px}
-.toc-label:first-child{margin-top:0}
-.toc a{display:block;padding:6px 22px 6px 26px;color:var(--ink);
-  font-size:13px;line-height:1.35;border-left:3px solid transparent}
-.toc a:hover{background:var(--hover);text-decoration:none;color:var(--walnut)}
-.toc a.active{border-left-color:var(--lapis);color:var(--walnut);
-  background:linear-gradient(90deg,rgba(30,58,138,0.06),transparent 80%);
-  font-weight:600}
-.toc a .num{display:inline-block;width:20px;color:var(--muted);
-  font-family:var(--mono);font-size:11px}
-.toc a.active .num{color:var(--lapis)}
-
-/* ============================================================
-   Main content
-   ============================================================ */
-.main{padding:24px 36px 80px;max-width:1100px;width:100%}
-section{padding-top:8px;scroll-margin-top:calc(var(--bar-h) + 12px)}
-section + section{margin-top:14px;padding-top:24px;
-  border-top:1px solid var(--rule)}
-section h1{font-family:var(--serif);font-weight:600;font-size:30px;
-  color:var(--walnut);margin:0 0 4px;letter-spacing:-0.005em}
-section h1 .eyebrow{display:block;font-family:var(--ui);font-weight:500;
-  font-size:11px;color:var(--lapis);text-transform:uppercase;
-  letter-spacing:0.16em;margin-bottom:6px}
-section h2{font-family:var(--serif);font-weight:600;font-size:19px;
-  color:var(--walnut);margin:22px 0 8px}
-section h3{font-family:var(--ui);font-weight:600;font-size:13px;
-  color:var(--lapis);text-transform:uppercase;letter-spacing:0.08em;
-  margin:18px 0 6px}
-section p{margin:0.6em 0}
-
-.hero-media{margin:12px 0 16px;border:1px solid var(--rule);
-  background:var(--paper);border-radius:5px;overflow:hidden}
-.hero-media img{display:block;width:100%;max-height:430px;object-fit:cover}
-
-/* ============================================================
-   Status card
-   ============================================================ */
-.status-card{background:var(--paper);border:1px solid var(--rule);
-  border-top:4px solid var(--lapis);border-radius:6px;
-  padding:18px 22px;margin:6px 0 28px;
-  box-shadow:0 1px 2px rgba(31,26,20,0.04)}
-.status-row{display:flex;align-items:flex-start;gap:14px;flex-wrap:wrap}
-.status-row + .status-row{margin-top:10px;padding-top:10px;
-  border-top:1px dashed var(--rule)}
-.status-label{font-family:var(--ui);font-size:11px;color:var(--muted);
-  text-transform:uppercase;letter-spacing:0.1em;
-  flex:0 0 110px;padding-top:3px}
-.status-val{flex:1;font-size:14px}
-.status-val .strong{font-weight:600;color:var(--walnut)}
-.pill{display:inline-block;padding:3px 10px;border-radius:11px;
-  font-family:var(--ui);font-size:11px;font-weight:600;
-  letter-spacing:0.04em;text-transform:uppercase}
-.pill-private{background:var(--pill-bg);color:var(--walnut);border:1px solid var(--pill-border)}
-.pill-public{background:#D8EBD3;color:var(--ok);border:1px solid var(--ok)}
-.pill-gate{background:#FAEFE0;color:var(--warn);border:1px solid var(--warn)}
-.pill-fam{background:#E6EAF5;color:var(--lapis);border:1px solid var(--lapis);margin-right:6px}
-.pill-block{background:#F5DBD2;color:var(--block);border:1px solid var(--block)}
-
-.gates{list-style:none;margin:0;padding:0;display:flex;
-  flex-direction:column;gap:8px}
-.gate{display:flex;align-items:flex-start;gap:10px}
-.gate-dot{flex:0 0 12px;width:12px;height:12px;border-radius:50%;
-  margin-top:5px;background:var(--warn);
-  box-shadow:0 0 0 2px var(--paper),0 0 0 3px var(--warn)}
-.gate-dot.ok{background:var(--ok);box-shadow:0 0 0 2px var(--paper),0 0 0 3px var(--ok)}
-.gate-dot.block{background:var(--block);box-shadow:0 0 0 2px var(--paper),0 0 0 3px var(--block)}
-.gate-label{flex:1;font-size:13px;color:var(--ink)}
-.gate-label code{font-size:11px;color:var(--muted);background:transparent;
-  border:1px solid var(--rule);padding:1px 4px}
-
-/* ============================================================
-   File viewer (collapsible)
-   ============================================================ */
-.file{margin:14px 0;background:var(--paper);border:1px solid var(--rule);
-  border-radius:5px;overflow:hidden}
-.file-head{display:flex;align-items:center;gap:10px;
-  padding:9px 14px;background:#FAF6EC;cursor:pointer;
-  border-bottom:1px solid var(--rule);font-size:13px;
-  user-select:none;transition:background 80ms}
-.file-head:hover{background:#F3ECD7}
-.file-head .icon{flex:0 0 18px;width:18px;height:18px;
-  display:flex;align-items:center;justify-content:center;
-  color:var(--muted);font-size:11px;transition:transform 120ms}
-.file.open .file-head .icon{transform:rotate(90deg)}
-.file-name{font-family:var(--mono);font-size:12.5px;color:var(--walnut);
-  font-weight:500}
-.file-type{display:inline-block;font-family:var(--ui);font-size:10px;
-  letter-spacing:0.08em;text-transform:uppercase;
-  background:var(--cream);color:var(--muted);padding:2px 6px;
-  border-radius:2px;margin-left:6px}
-.file-desc{flex:1;color:var(--muted);font-size:12px;text-align:right;
-  padding-left:12px}
-.file-body{display:none;padding:14px 16px;background:var(--paper);
-  font-size:13.5px}
-.file.open .file-body{display:block}
-.file-actions{display:flex;gap:8px;align-items:center;margin-left:6px}
-.file-actions a{font-size:11px;color:var(--muted);
-  border:1px solid var(--rule);padding:2px 6px;border-radius:2px;
-  letter-spacing:0.04em;text-transform:uppercase}
-.file-actions a:hover{color:var(--lapis);border-color:var(--lapis);text-decoration:none}
-
-/* ============================================================
-   Tables
-   ============================================================ */
-table.data{width:100%;border-collapse:collapse;font-size:12px;
-  font-family:var(--mono);background:var(--paper)}
-table.data th,table.data td{padding:5px 8px;text-align:left;
-  border-bottom:1px solid var(--rule);vertical-align:top;
-  white-space:nowrap;max-width:280px;overflow:hidden;
-  text-overflow:ellipsis}
-table.data th{background:var(--walnut);color:var(--cream);
-  font-family:var(--ui);font-size:11px;font-weight:600;
-  letter-spacing:0.04em;text-transform:uppercase;cursor:pointer;
-  user-select:none;position:sticky;top:0;z-index:1}
-table.data th:hover{background:#52341E}
-table.data tr:nth-child(even) td{background:#FBF7EC}
-table.data tr:hover td{background:#F3ECD7}
-table.data tr.warn td{background:#FBEED2}
-table.data tr.warn:hover td{background:#F5E2B7}
-.table-wrap{overflow:auto;max-height:540px;border:1px solid var(--rule);
-  border-radius:4px}
-.table-stats{font-size:11px;color:var(--muted);padding:4px 0 8px;
-  font-family:var(--ui)}
-
-/* ============================================================
-   Cards
-   ============================================================ */
-.cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));
-  gap:12px;margin:14px 0}
-.card{background:var(--paper);border:1px solid var(--rule);
-  border-radius:4px;padding:14px 16px;font-size:13px}
-.card .k{font-family:var(--ui);font-size:11px;color:var(--muted);
-  text-transform:uppercase;letter-spacing:0.06em;margin-bottom:4px}
-.card .v{font-family:var(--serif);font-size:16px;color:var(--walnut);font-weight:600;line-height:1.3}
-.card .v .sub{display:block;font-family:var(--ui);font-size:12px;
-  color:var(--muted);font-weight:400;margin-top:3px}
-
-/* ============================================================
-   Callouts (scope boundary, cultural notes)
-   ============================================================ */
-.callout{border-left:4px solid var(--cedar);background:#FAF6EC;
-  padding:14px 18px;margin:14px 0;font-size:13.5px;border-radius:0 4px 4px 0}
-.callout.warn{border-color:var(--warn);background:#FCEFC6}
-.callout.block{border-color:var(--block);background:#F8E3DC}
-.callout .lab{font-family:var(--ui);font-size:10.5px;font-weight:700;
-  text-transform:uppercase;letter-spacing:0.08em;color:var(--walnut);
-  margin-bottom:6px;display:block}
-.callout.warn .lab{color:var(--warn)}
-.callout.block .lab{color:var(--block)}
-.callout p:first-of-type{margin-top:0}
-.callout p:last-of-type{margin-bottom:0}
-
-/* ============================================================
-   CAD viewer (model-viewer slot + poster fallback)
-   ============================================================ */
-.cad-wrap{margin:14px 0;background:var(--paper);
-  border:1px solid var(--rule);border-radius:5px;overflow:hidden}
-.cad-head{display:flex;align-items:center;gap:10px;padding:9px 14px;
-  background:#FAF6EC;border-bottom:1px solid var(--rule);font-size:12.5px}
-.cad-head .dot{width:10px;height:10px;border-radius:50%;
-  background:var(--muted);box-shadow:0 0 0 2px var(--paper)}
-.cad-head.live .dot{background:var(--ok)}
-.cad-head .label{font-family:var(--ui);text-transform:uppercase;
-  letter-spacing:0.08em;font-size:10.5px;font-weight:700;color:var(--walnut)}
-.cad-head .note{color:var(--muted);font-size:12px}
-.cad-stage{position:relative;background:#FFFCF3;min-height:480px;
-  display:flex;align-items:center;justify-content:center}
-model-viewer{width:100%;height:560px;display:block;background:#FFFCF3;
-  --poster-color:transparent}
-.cad-fallback{padding:24px;text-align:center;width:100%}
-.cad-fallback img,.cad-fallback svg{max-width:100%;max-height:520px;
-  display:block;margin:0 auto 14px}
-.cad-fallback .msg{font-family:var(--ui);font-size:13px;color:var(--muted);
-  max-width:520px;margin:0 auto}
-.cad-fallback .msg .strong{color:var(--walnut);font-weight:600}
-.cad-poster{margin:14px 0;background:var(--paper);border:1px solid var(--rule);
-  border-radius:5px;overflow:hidden}
-.cad-poster img{display:block;width:100%;max-height:420px;object-fit:contain;
-  background:#FFFCF3}
-
-/* ============================================================
-   Markdown rendered content
-   ============================================================ */
-.md{font-size:14px;line-height:1.6}
-.md h1,.md h2,.md h3,.md h4{font-family:var(--serif);color:var(--walnut);
-  margin-top:1.2em;margin-bottom:0.4em;line-height:1.3}
-.md h1{font-size:20px} .md h2{font-size:17px;border-bottom:1px solid var(--rule);padding-bottom:3px}
-.md h3{font-size:14px;font-family:var(--ui);text-transform:uppercase;
-  letter-spacing:0.06em;color:var(--lapis)}
-.md h4{font-size:13px}
-.md p{margin:0.65em 0}
-.md ul,.md ol{padding-left:22px;margin:0.5em 0}
-.md li{margin:3px 0}
-.md blockquote{border-left:3px solid var(--cedar);padding-left:14px;
-  color:var(--muted);font-style:italic;margin:0.8em 0}
-.md table{width:100%;border-collapse:collapse;margin:0.8em 0;font-size:12.5px}
-.md table th,.md table td{padding:5px 8px;border:1px solid var(--rule);
-  text-align:left;vertical-align:top}
-.md table th{background:var(--walnut);color:var(--cream);
-  font-family:var(--ui);font-size:11px;letter-spacing:0.04em}
-.md table tr:nth-child(even) td{background:#FBF7EC}
-.md code{font-size:0.88em}
-.md hr{border:none;border-top:1px solid var(--gold);margin:1em 0}
-
-/* ============================================================
-   Tag rows + checklists
-   ============================================================ */
-.tag-row{display:flex;flex-wrap:wrap;gap:6px;margin:8px 0}
-.tag{display:inline-block;font-family:var(--ui);font-size:11px;
-  background:var(--cream);color:var(--walnut);padding:3px 9px;
-  border-radius:3px;border:1px solid var(--rule);letter-spacing:0.02em}
-.muted{color:var(--muted)}
-.eyebrow{font-family:var(--ui);font-size:11px;color:var(--lapis);
-  text-transform:uppercase;letter-spacing:0.16em;margin-bottom:4px}
-.placeholder{background:#FAF6EC;border:1px dashed var(--cedar);
-  border-radius:4px;padding:14px 18px;color:var(--muted);
-  font-size:13.5px;font-style:italic}
-.placeholder .strong{color:var(--walnut);font-style:normal;font-weight:600}
-
-/* ============================================================
-   Wolfram Cloud embed block
-   ============================================================ */
-.wolfram-embed-wrap{margin:14px 0}
-.wolfram-embed-status{display:flex;align-items:center;gap:10px;
-  padding:9px 14px;background:#FAF6EC;border:1px solid var(--rule);
-  border-radius:4px 4px 0 0;font-size:12.5px}
-.wolfram-embed-status.live{background:#E8F1E5;border-color:var(--ok)}
-.wolfram-embed-status.live .dot{background:var(--ok)}
-.wolfram-embed-status.pending{background:#FCEFC6;border-color:var(--pill-border)}
-.wolfram-embed-status.pending .dot{background:var(--warn)}
-.wolfram-embed-status.private{background:#EEEAE0;border-color:var(--muted)}
-.wolfram-embed-status.private .dot{background:var(--muted)}
-.wolfram-embed-status.failed{background:#F8E3DC;border-color:var(--block)}
-.wolfram-embed-status.failed .dot{background:var(--block)}
-.wolfram-embed-status .dot{width:10px;height:10px;border-radius:50%;
-  flex:0 0 10px;box-shadow:0 0 0 2px var(--paper)}
-.wolfram-embed-status .label{font-family:var(--ui);text-transform:uppercase;
-  letter-spacing:0.08em;font-size:10.5px;font-weight:700;color:var(--walnut)}
-.wolfram-embed-iframe{width:100%;height:780px;border:1px solid var(--rule);
-  border-top:none;border-radius:0 0 4px 4px;display:block;background:var(--paper)}
-.wolfram-pending-body{padding:16px 22px;background:var(--paper);
-  border:1px solid var(--rule);border-top:none;border-radius:0 0 4px 4px;
-  color:var(--ink);font-size:13.5px}
-.wolfram-pending-body p{margin:0.5em 0}
-.wolfram-pending-body code{font-size:11.5px}
-
-/* Search highlight */
-mark.hit{background:var(--gold);color:var(--ink);
-  padding:0 2px;border-radius:2px}
-
-/* ============================================================
-   Print + mobile
-   ============================================================ */
-@media print{
-  .app-bar,.sidebar,.actions,.file-head{display:none}
-  .app{grid-template-columns:1fr}
-  .file-body{display:block !important;border:none;padding:0}
-  .main{max-width:none;padding:0}
-  model-viewer{display:none}
-}
-@media (max-width:880px){
-  .app{grid-template-columns:1fr}
-  .sidebar{display:none}
-  .actions .search{width:180px}
-  .main{padding:16px}
-  model-viewer{height:380px}
-}
-
-</style>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Djembe — Stave-Built Goblet Drum — Explorer</title>
+  <style>
+    :root {
+      --bg: #f4efe6;
+      --panel: #fffaf4;
+      --ink: #2b221c;
+      --muted: #6f6154;
+      --line: #d9cbb7;
+      --accent: #8f5f3a;
+      --ok: #355c3c;
+      --warn: #8a5a20;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Georgia, "Iowan Old Style", serif;
+      background: linear-gradient(180deg, #efe6d7 0%, #f8f3eb 40%, var(--bg) 100%);
+      color: var(--ink);
+      line-height: 1.55;
+    }
+    main { max-width: 980px; margin: 0 auto; padding: 32px 18px 56px; }
+    .hero, .panel {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      box-shadow: 0 12px 28px rgba(43,34,28,.08);
+    }
+    .hero { padding: 28px; margin-bottom: 24px; }
+    .panel { padding: 24px; margin-bottom: 20px; }
+    .eyebrow {
+      font: 600 12px/1.2 Arial, sans-serif;
+      letter-spacing: .16em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin: 0 0 10px;
+    }
+    h1 { font: 700 36px/1.08 Arial, sans-serif; margin: 0 0 10px; }
+    h2 { font: 700 22px/1.1 Arial, sans-serif; margin: 0 0 12px; }
+    p { margin: 0 0 14px; }
+    .chips { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 16px; }
+    .chip {
+      border-radius: 999px;
+      padding: 8px 12px;
+      font: 600 13px/1 Arial, sans-serif;
+      border: 1px solid var(--line);
+      background: #f8f2e8;
+    }
+    .chip.readiness { border-color: #b8895f; background: #f8eadb; color: #5e3a1e; }
+    .chip.authority { border-color: #8eb090; background: #ebf3ec; color: var(--ok); }
+    a { color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: .14em; }
+    code { font-family: "Courier New", monospace; font-size: .95em; }
+    .meta {
+      font: 600 12px/1.3 Arial, sans-serif;
+      color: var(--muted);
+      letter-spacing: .03em;
+      text-transform: uppercase;
+      margin-bottom: 8px;
+      display: block;
+    }
+    .artifact-list {
+      list-style: none;
+      padding: 0;
+      margin: 18px 0 0;
+      display: grid;
+      gap: 12px;
+    }
+    .artifact-list li { border-top: 1px solid var(--line); padding-top: 12px; }
+    .note { color: var(--warn); }
+    footer {
+      margin-top: 36px;
+      font: 12px/1.4 "Courier New", monospace;
+      color: var(--muted);
+      text-align: center;
+    }
+    @media (max-width: 640px) {
+      h1 { font-size: 28px; }
+      main { padding: 20px 14px 42px; }
+    }
+  </style>
 </head>
 <body>
+  <main>
+    <section class="hero">
+      <p class="eyebrow">Instrument-Maker V5 Export · tonykoop/djembe</p>
+      <h1>Djembe — Stave-Built Goblet Drum</h1>
+      <p>Engineering documentation for a stave-built djembe — the West African goblet drum. Includes Helmholtz / Webster horn FEM analysis, segmented-construction study, and parametric goblet geometry CSV. Built at Morgan Drums (St. Paul, MN) 2010.</p>
+      <div class="chips">
+        <span class="chip readiness">Status: L1 bare-bones packet</span>
+        <span class="chip authority">Authority split: fabrication vs derived preview</span>
+        <span class="chip">Family: membranophone · stave-built goblet drum</span>
+      </div>
+    </section>
 
-<header class="app-bar">
-  <div class="brand">
-    <span class="wordmark"><em>Heifer Zephyr</em></span>
-    <span class="instrument">djembe · Studio Explorer</span>
-  </div>
-  <div class="actions">
-    <input id="search" class="search" placeholder="Search packet content…" aria-label="Search packet content">
-    <a class="action-btn" href="../instrument-showcase/site/library.html" title="Browse all studio explorers">← Library</a>
-    <a class="action-btn" href="https://github.com/tonykoop/djembe" target="_blank" rel="noopener">GitHub</a>
-  </div>
-</header>
+    <section class="panel">
+      <p class="meta">Manifest</p>
+      <h2>Bundle entry points</h2>
+      <p>Machine-readable handoff: <a href="data/deliverables-export.json"><code>data/deliverables-export.json</code></a></p>
+      
+      <p class="note">This card is not build-ready evidence. Critical geometry needs reviewed DXF or CAD authority before any L3 promotion claim.</p>
+    </section>
 
-<div class="app">
+    <section class="panel card">
+      <p class="meta">Wolfram Cloud model</p>
+      <h2>Interactive acoustic model</h2>
+      <p><a href="https://www.wolframcloud.com/obj/wrfcoin/Musical_Instruments/percussion/djembe/djembe-goblet-acoustics.wl" target="_blank" rel="noopener">&#8599; Open in Wolfram Cloud</a> &nbsp;·&nbsp;
+      Source included as <code>source_only</code> evidence — no executed runtime output claimed.</p>
+      <iframe
+        src="https://www.wolframcloud.com/obj/wrfcoin/Musical_Instruments/percussion/djembe/djembe-goblet-acoustics.wl"
+        title="Interactive Wolfram model"
+        loading="lazy"
+        style="width:100%;height:600px;border:1px solid var(--line);border-radius:12px;background:#fff;margin-top:12px">
+      </iframe>
+    </section>
 
-<nav class="sidebar" aria-label="Sections">
-  <ol class="toc" id="toc"></ol>
-</nav>
-
-<main class="main">
-
-<article class="status-card">
-  <div class="status-row">
-    <div class="status-label">Build target</div>
-    <div class="status-val"><span class="strong">stave-built djembe evidence map and validation starter</span> · Djembe Bare-Bones Starter Packet</div>
-  </div>
-
-  <div class="status-row">
-    <div class="status-label">Focus</div>
-    <div class="status-val"><span class="strong">bare-bones packet for djembe acoustics evidence, construction decisions, and validation gates</span></div>
-  </div>
-  <div class="status-row">
-    <div class="status-label">Status</div>
-    <div class="status-val"><span class="pill pill-private">Private review</span>&nbsp;&nbsp;<span class="pill pill-block">Public-release blocked</span> Packet version <span class="strong">bare-bones readiness packet</span></div>
-  </div>
-  <div class="status-row">
-    <div class="status-label">Family</div>
-    <div class="status-val"><span class="pill pill-fam">stave-built djembe</span><span class="pill pill-fam">goblet drum</span><span class="pill pill-fam">membrane percussion</span></div>
-  </div>
-  <div class="status-row">
-    <div class="status-label">Release gates</div>
-    <div class="status-val"><ul class="gates"><li class="gate"><span class="gate-dot block" title="Open"></span><span class="gate-label">Record repeatable mic/FFT strike measurements for bass, open tone, and slap.</span></li><li class="gate"><span class="gate-dot block" title="Open"></span><span class="gate-label">Select one construction path before cut lists or jig drawings are treated as actionable.</span></li><li class="gate"><span class="gate-dot block" title="Open"></span><span class="gate-label">Promote reviewed CAD, DXF, drawing, or design-table authority before fabrication geometry claims.</span></li><li class="gate"><span class="gate-dot block" title="Open"></span><span class="gate-label">Verify BOM sources, dimensions, and safety factors at purchase and build time.</span></li><li class="gate"><span class="gate-dot block" title="Open"></span><span class="gate-label">Document head material, head diameter, rope/ring hardware, and tuning state for any acoustic claim.</span></li></ul></div>
-  </div>
-</article>
-
-<section id="overview" data-toc="Overview" data-toc-group="Project">
-  <h1><span class="eyebrow">01 - Overview</span>Djembe Bare-Bones Starter Packet</h1>
-  <figure class="hero-media"><img src="images/hero-render.png" alt="djembe — concept render" loading="lazy"></figure>
-  <p>This explorer is a studio index for the djembe repo's V5 starter packet. It connects the existing README, Helmholtz/FEM analysis, historical CAD/archive material, photos, BOM scaffold, validation loop, visual authority register, validation gates, and risks without upgrading the repo to build-ready status.</p>
-  <div class="callout warn">
-    <span class="lab">Readiness boundary</span>
-    <p>Fabrication geometry still requires reviewed CAD, DXF, drawing, or design-table authority. Acoustic claims still require repeatable mic/FFT strike measurements with documented head, shell, tuning, and room conditions.</p>
-  </div>
-</section>
-
-<section id="repo-assets" data-toc="Repo Artifacts" data-toc-group="Project">
-  <h1><span class="eyebrow">· Repo artifacts</span>Design tables · research · source files</h1>
-<div class="file open"><div class="file-head" onclick="toggleFile(this)"><span class="icon">▶</span><span class="file-name">README.md</span><span class="file-type">MD</span><span class="file-desc">Repository narrative</span><span class="file-actions"><a href="README.md" target="_blank" rel="noopener">Open</a></span></div><div class="file-body" data-md="README.md"></div></div>
-<div class="file"><div class="file-head" onclick="toggleFile(this)"><span class="icon">▶</span><span class="file-name">SKILLS.md</span><span class="file-type">MD</span><span class="file-desc">Skill index and cross-repo links</span><span class="file-actions"><a href="SKILLS.md" target="_blank" rel="noopener">Open</a></span></div><div class="file-body" data-md="SKILLS.md"></div></div>
-<div class="file"><div class="file-head" onclick="toggleFile(this)"><span class="icon">▶</span><span class="file-name">bom.csv</span><span class="file-type">CSV</span><span class="file-desc">Dimension or registry table</span><span class="file-actions"><a href="bom.csv" target="_blank" rel="noopener">Open</a></span></div><div class="file-body" data-csv="bom.csv"></div></div>
-<div class="file"><div class="file-head" onclick="toggleFile(this)"><span class="icon">▶</span><span class="file-name">validation.csv</span><span class="file-type">CSV</span><span class="file-desc">Dimension or registry table</span><span class="file-actions"><a href="validation.csv" target="_blank" rel="noopener">Open</a></span></div><div class="file-body" data-csv="validation.csv"></div></div>
-<div class="file"><div class="file-head" onclick="toggleFile(this)"><span class="icon">▶</span><span class="file-name">validation-loop.csv</span><span class="file-type">CSV</span><span class="file-desc">Next-build measurement loop</span><span class="file-actions"><a href="validation-loop.csv" target="_blank" rel="noopener">Open</a></span></div><div class="file-body" data-csv="validation-loop.csv"></div></div>
-<div class="file"><div class="file-head" onclick="toggleFile(this)"><span class="icon">▶</span><span class="file-name">visual-output-register.csv</span><span class="file-type">CSV</span><span class="file-desc">Visual authority register</span><span class="file-actions"><a href="visual-output-register.csv" target="_blank" rel="noopener">Open</a></span></div><div class="file-body" data-csv="visual-output-register.csv"></div></div>
-<div class="cards"><div class="card"><div class="k">Artifact</div><div class="v">README.md<span class="sub">analysis/helmholtz-fem/README.md</span></div><p style="margin-top:8px"><a href="analysis/helmholtz-fem/README.md" target="_blank" rel="noopener">Open</a></p></div><div class="card"><div class="k">Artifact</div><div class="v">capstone.md<span class="sub">analysis/helmholtz-fem/capstone.md</span></div><p style="margin-top:8px"><a href="analysis/helmholtz-fem/capstone.md" target="_blank" rel="noopener">Open</a></p></div><div class="card"><div class="k">Artifact</div><div class="v">closed-form.md<span class="sub">analysis/helmholtz-fem/closed-form.md</span></div><p style="margin-top:8px"><a href="analysis/helmholtz-fem/closed-form.md" target="_blank" rel="noopener">Open</a></p></div><div class="card"><div class="k">Artifact</div><div class="v">results.md<span class="sub">analysis/helmholtz-fem/results.md</span></div><p style="margin-top:8px"><a href="analysis/helmholtz-fem/results.md" target="_blank" rel="noopener">Open</a></p></div></div>
-</section>
-
-<section id="cad" data-toc="CAD Export Queue" data-toc-group="Project">
-  <h1><span class="eyebrow">02 · CAD export queue</span>glTF / GLB pending</h1>
-  <div class="callout warn"><span class="lab">Model-viewer asset needed</span>
-    <p>Source CAD exists, but no browser-renderable <code>.glb</code> or <code>.gltf</code> was found yet. Export the chosen SolidWorks assembly into the repo's CAD folder and rerun this generator; the explorer will then inline small <code>.glb</code> files automatically.</p>
-  </div>
-  <figure class="cad-poster"><img src="CAD/Segmented%20Djembe/large-djembe/Large%20Djembe%20Segmented%20Pattern%201.PNG" alt="CAD source preview"></figure>
-  <div class="cards"><div class="card"><div class="k">CAD source</div><div class="v">5degree 18 part 36 face.SLDPRT<span class="sub">SolidWorks/source model</span></div><p style="margin-top:8px"><a href="CAD/legacy-archive-2018/wood-stave-djembe/5degree%2018%20part%2036%20face.SLDPRT" target="_blank" rel="noopener">Open</a></p></div><div class="card"><div class="k">CAD source</div><div class="v">Djembe C - 3 flat face.SLDASM<span class="sub">SolidWorks/source model</span></div><p style="margin-top:8px"><a href="CAD/legacy-archive-2018/wood-stave-djembe/Djembe%20C%20-%203%20flat%20face.SLDASM" target="_blank" rel="noopener">Open</a></p></div><div class="card"><div class="k">CAD source</div><div class="v">Djimbey A.SLDPRT<span class="sub">SolidWorks/source model</span></div><p style="margin-top:8px"><a href="CAD/legacy-archive-2018/wood-stave-djembe/Djimbey%20A.SLDPRT" target="_blank" rel="noopener">Open</a></p></div><div class="card"><div class="k">CAD source</div><div class="v">Djimbey B-Cut-Extrude1.SLDPRT<span class="sub">SolidWorks/source model</span></div><p style="margin-top:8px"><a href="CAD/legacy-archive-2018/wood-stave-djembe/Djimbey%20B-Cut-Extrude1.SLDPRT" target="_blank" rel="noopener">Open</a></p></div><div class="card"><div class="k">CAD source</div><div class="v">Djimbey B.SLDPRT<span class="sub">SolidWorks/source model</span></div><p style="margin-top:8px"><a href="CAD/legacy-archive-2018/wood-stave-djembe/Djimbey%20B.SLDPRT" target="_blank" rel="noopener">Open</a></p></div><div class="card"><div class="k">CAD source</div><div class="v">Djimbey C-Cut-Extrude1.SLDPRT<span class="sub">SolidWorks/source model</span></div><p style="margin-top:8px"><a href="CAD/legacy-archive-2018/wood-stave-djembe/Djimbey%20C-Cut-Extrude1.SLDPRT" target="_blank" rel="noopener">Open</a></p></div><div class="card"><div class="k">CAD source</div><div class="v">Djimbey C.SLDPRT<span class="sub">SolidWorks/source model</span></div><p style="margin-top:8px"><a href="CAD/legacy-archive-2018/wood-stave-djembe/Djimbey%20C.SLDPRT" target="_blank" rel="noopener">Open</a></p></div><div class="card"><div class="k">CAD source</div><div class="v">Plank Template C Version 2.SLDASM<span class="sub">SolidWorks/source model</span></div><p style="margin-top:8px"><a href="CAD/legacy-archive-2018/wood-stave-djembe/Plank%20Template%20C%20Version%202.SLDASM" target="_blank" rel="noopener">Open</a></p></div><div class="card"><div class="k">CAD source</div><div class="v">Plank Template C.SLDASM<span class="sub">SolidWorks/source model</span></div><p style="margin-top:8px"><a href="CAD/legacy-archive-2018/wood-stave-djembe/Plank%20Template%20C.SLDASM" target="_blank" rel="noopener">Open</a></p></div></div>
-
-</section>
-
-<section id="bom" data-toc="Bill of Materials" data-toc-group="Build">
-  <h1><span class="eyebrow">· Bill of Materials</span>Bill of Materials</h1>
-<div class="file open"><div class="file-head" onclick="toggleFile(this)"><span class="icon">▶</span><span class="file-name">bom.csv</span><span class="file-type">CSV</span><span class="file-desc">Line items · planning estimate</span><span class="file-actions"><a href="bom.csv" target="_blank" rel="noopener">Open</a></span></div><div class="file-body" data-csv="bom.csv"></div></div>
-</section>
-
-<section id="design" data-toc="Design" data-toc-group="Design">
-  <h1><span class="eyebrow">· Design</span>Design</h1>
-<div class="file open"><div class="file-head" onclick="toggleFile(this)"><span class="icon">▶</span><span class="file-name">design.md</span><span class="file-type">MD</span><span class="file-desc">Design narrative</span><span class="file-actions"><a href="design.md" target="_blank" rel="noopener">Open</a></span></div><div class="file-body" data-md="design.md"></div></div>
-</section>
-
-<section id="validation" data-toc="Validation Gates" data-toc-group="Validate">
-  <h1><span class="eyebrow">· Validation Gates</span>Validation Gates</h1>
-<div class="file open"><div class="file-head" onclick="toggleFile(this)"><span class="icon">▶</span><span class="file-name">validation.csv</span><span class="file-type">CSV</span><span class="file-desc">Checks · methods · tolerances · gates</span><span class="file-actions"><a href="validation.csv" target="_blank" rel="noopener">Open</a></span></div><div class="file-body" data-csv="validation.csv"></div></div>
-<div class="file open"><div class="file-head" onclick="toggleFile(this)"><span class="icon">▶</span><span class="file-name">validation-loop.csv</span><span class="file-type">CSV</span><span class="file-desc">Prediction · method · measurement · next action</span><span class="file-actions"><a href="validation-loop.csv" target="_blank" rel="noopener">Open</a></span></div><div class="file-body" data-csv="validation-loop.csv"></div></div>
-<div class="file"><div class="file-head" onclick="toggleFile(this)"><span class="icon">▶</span><span class="file-name">visual-output-register.csv</span><span class="file-type">CSV</span><span class="file-desc">Reference-only photos, scans, and previews</span><span class="file-actions"><a href="visual-output-register.csv" target="_blank" rel="noopener">Open</a></span></div><div class="file-body" data-csv="visual-output-register.csv"></div></div>
-</section>
-
-<section id="risks" data-toc="Risk Register" data-toc-group="Validate">
-  <h1><span class="eyebrow">· Risk Register</span>Risk Register</h1>
-<div class="file open"><div class="file-head" onclick="toggleFile(this)"><span class="icon">▶</span><span class="file-name">risks.md</span><span class="file-type">MD</span><span class="file-desc">Risk register with mitigations</span><span class="file-actions"><a href="risks.md" target="_blank" rel="noopener">Open</a></span></div><div class="file-body" data-md="risks.md"></div></div>
-</section>
-
-<section id="images" data-toc="Images" data-toc-group="Publish">
-  <h1><span class="eyebrow">· Images</span>Concept renders</h1>
-  <div class="cards">
-    <figure class="cad-poster"><img src="images/macro/rope-tuning-weave.png" alt="djembe — rope tuning weave macro" loading="lazy"></figure>
-    <figure class="cad-poster"><img src="images/macro/stave-seams.png" alt="djembe — stave seams macro" loading="lazy"></figure>
-  </div>
-</section>
-
-<section id="capstone" data-toc="Capstone Deliverables" data-toc-group="Publish">
-  <h1><span class="eyebrow">· Capstone deliverables</span>Deck · print packet · explorer</h1>
-  <div class="cards"><div class="card"><div class="k">Manifest</div><div class="v">capstone-manifest.json<span class="sub">Artifact inventory; release gates; required-before-public list</span></div><p style="margin-top:8px"><a href="capstone-manifest.json">Open JSON</a></p></div><div class="card"><div class="k">Studio explorer</div><div class="v">explorer.html<span class="sub">This document. Generated by instrument-maker/scripts/generate_explorer.py.</span></div><p style="margin-top:8px"><a href="explorer.html">Reload</a></p></div></div>
-</section>
-
-</main>
-</div>
-
-
-
-<script>
-(function(){
-// =====================================================
-// 1. Utilities
-// =====================================================
-function escapeHTML(s){
-  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;')
-          .replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
-}
-function inlineMD(s){
-  return s
-    .replace(/`([^`]+)`/g, (m,c)=>'<code>'+c+'</code>')
-    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-    .replace(/(^|[^*])\*([^*]+)\*/g, '$1<em>$2</em>')
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
-}
-
-// =====================================================
-// 2. CSV viewer (data-csv="filename")
-// =====================================================
-function parseCSVRow(line){
-  const out = []; let cur = ''; let q = false;
-  for (let i=0; i<line.length; i++){
-    const c = line[i];
-    if (q){
-      if (c === '"' && line[i+1] === '"'){ cur += '"'; i++; }
-      else if (c === '"'){ q = false; }
-      else cur += c;
-    } else {
-      if (c === ','){ out.push(cur); cur = ''; }
-      else if (c === '"'){ q = true; }
-      else cur += c;
-    }
-  }
-  out.push(cur);
-  return out;
-}
-function renderCSV(target, text){
-  const lines = text.replace(/\r/g,'').split('\n').filter(l => l.length);
-  if (!lines.length){ target.innerHTML = '<p class="muted">Empty</p>'; return; }
-  const head = parseCSVRow(lines.shift());
-  const rows = lines.map(parseCSVRow);
-  const wrap = document.createElement('div'); wrap.className = 'table-wrap';
-  const tbl = document.createElement('table'); tbl.className = 'data';
-  const thead = document.createElement('thead'); const tr = document.createElement('tr');
-  head.forEach(h => { const th = document.createElement('th'); th.textContent = h; tr.appendChild(th); });
-  thead.appendChild(tr); tbl.appendChild(thead);
-  const tbody = document.createElement('tbody');
-  rows.forEach(r => {
-    const trr = document.createElement('tr');
-    r.forEach(c => { const td = document.createElement('td'); td.textContent = c; td.title = c; trr.appendChild(td); });
-    tbody.appendChild(trr);
-  });
-  tbl.appendChild(tbody); wrap.appendChild(tbl); target.appendChild(wrap);
-  const stats = document.createElement('div'); stats.className = 'table-stats';
-  stats.textContent = rows.length + ' rows · ' + head.length + ' columns';
-  target.appendChild(stats);
-}
-
-// =====================================================
-// 3. Tiny markdown renderer (data-md="filename")
-// =====================================================
-function renderMD(src){
-  const lines = src.replace(/\r/g,'').split('\n');
-  const out = []; let i = 0;
-  while (i < lines.length){
-    const line = lines[i];
-    let m;
-    // Heading
-    if ((m = line.match(/^(#{1,4})\s+(.*)$/))){
-      const lvl = m[1].length;
-      out.push('<h'+lvl+'>'+inlineMD(escapeHTML(m[2]))+'</h'+lvl+'>');
-      i++; continue;
-    }
-    // HR
-    if (line.match(/^---+\s*$/)){ out.push('<hr>'); i++; continue; }
-    // Code fence
-    if (line.startsWith('```')){
-      const buf = []; i++;
-      while (i < lines.length && !lines[i].startsWith('```')){
-        buf.push(lines[i]); i++;
-      }
-      i++;
-      out.push('<pre>'+escapeHTML(buf.join('\n'))+'</pre>');
-      continue;
-    }
-    // Table
-    if (line.match(/^\s*\|/) && lines[i+1] && lines[i+1].match(/^\s*\|[\s\-:\|]+\|\s*$/)){
-      const head = line.split('|').slice(1,-1).map(c=>c.trim());
-      i += 2;
-      const rows = [];
-      while (i < lines.length && lines[i].match(/^\s*\|/)){
-        rows.push(lines[i].split('|').slice(1,-1).map(c=>c.trim()));
-        i++;
-      }
-      let t = '<table><thead><tr>' + head.map(h=>'<th>'+inlineMD(escapeHTML(h))+'</th>').join('') + '</tr></thead><tbody>';
-      rows.forEach(r => {
-        t += '<tr>' + r.map(c=>'<td>'+inlineMD(escapeHTML(c))+'</td>').join('') + '</tr>';
-      });
-      t += '</tbody></table>';
-      out.push(t); continue;
-    }
-    // Blockquote
-    if (line.startsWith('> ')){
-      const buf = [];
-      while (i < lines.length && lines[i].startsWith('> ')){
-        buf.push(lines[i].replace(/^>\s?/, '')); i++;
-      }
-      out.push('<blockquote>' + renderMD(buf.join('\n')) + '</blockquote>');
-      continue;
-    }
-    // Unordered list
-    if (line.match(/^[-*]\s+/)){
-      const buf = [];
-      while (i < lines.length && lines[i].match(/^[-*]\s+/)){
-        buf.push('<li>' + inlineMD(escapeHTML(lines[i].replace(/^[-*]\s+/, ''))) + '</li>');
-        i++;
-      }
-      out.push('<ul>' + buf.join('') + '</ul>');
-      continue;
-    }
-    // Ordered list
-    if (line.match(/^\d+\.\s+/)){
-      const buf = [];
-      while (i < lines.length && lines[i].match(/^\d+\.\s+/)){
-        buf.push('<li>' + inlineMD(escapeHTML(lines[i].replace(/^\d+\.\s+/, ''))) + '</li>');
-        i++;
-      }
-      out.push('<ol>' + buf.join('') + '</ol>');
-      continue;
-    }
-    if (line.trim() === ''){ i++; continue; }
-    const buf = [line]; i++;
-    while (i < lines.length && lines[i].trim() !== '' &&
-           !lines[i].match(/^(#{1,4}\s|[-*]\s|\d+\.\s|>\s|\||---+|```)/)){
-      buf.push(lines[i]); i++;
-    }
-    out.push('<p>' + inlineMD(escapeHTML(buf.join(' '))) + '</p>');
-  }
-  return out.join('\n');
-}
-
-// =====================================================
-// 4. File viewers (data-csv / data-md) — fetch on demand
-// =====================================================
-async function fetchText(fn){
-  try {
-    const r = await fetch(fn, {cache: 'no-store'});
-    if (!r.ok) return null;
-    return await r.text();
-  } catch(e){ return null; }
-}
-async function initFiles(){
-  const csvs = document.querySelectorAll('[data-csv]');
-  for (const el of csvs){
-    const fn = el.dataset.csv;
-    const text = await fetchText(fn);
-    if (text === null){
-      el.innerHTML = '<p class="muted">Source not loadable in this context (likely local-file CORS). <a href="' + fn + '" target="_blank" rel="noopener">Open raw →</a></p>';
-      continue;
-    }
-    el.innerHTML = ''; renderCSV(el, text);
-  }
-  const mds = document.querySelectorAll('[data-md]');
-  for (const el of mds){
-    const fn = el.dataset.md;
-    const text = await fetchText(fn);
-    if (text === null){
-      el.innerHTML = '<p class="muted">Source not loadable in this context (likely local-file CORS). <a href="' + fn + '" target="_blank" rel="noopener">Open raw →</a></p>';
-      continue;
-    }
-    const wrap = document.createElement('div'); wrap.className = 'md';
-    wrap.innerHTML = renderMD(text);
-    el.innerHTML = ''; el.appendChild(wrap);
-  }
-}
-
-// =====================================================
-// 5. Toggle file viewer open/closed
-// =====================================================
-window.toggleFile = function(headEl){
-  headEl.parentElement.classList.toggle('open');
-};
-
-// =====================================================
-// 6. Build sidebar TOC from sections
-// =====================================================
-function buildTOC(){
-  const sidebar = document.getElementById('toc');
-  let lastGroup = null; let num = 0;
-  document.querySelectorAll('section[data-toc]').forEach(sec => {
-    const group = sec.dataset.tocGroup || '';
-    if (group !== lastGroup){
-      const lbl = document.createElement('li'); lbl.className = 'toc-label';
-      lbl.textContent = group;
-      sidebar.appendChild(lbl);
-      lastGroup = group;
-    }
-    num++;
-    const li = document.createElement('li');
-    const a = document.createElement('a');
-    a.href = '#' + sec.id;
-    a.innerHTML = '<span class="num">'+String(num).padStart(2,'0')+'</span>' + sec.dataset.toc;
-    li.appendChild(a); sidebar.appendChild(li);
-  });
-}
-
-// =====================================================
-// 7. Active section highlight
-// =====================================================
-function activeTOC(){
-  const links = {};
-  document.querySelectorAll('#toc a').forEach(a => {
-    links[a.getAttribute('href').slice(1)] = a;
-  });
-  const obs = new IntersectionObserver(entries => {
-    entries.forEach(en => {
-      const a = links[en.target.id]; if (!a) return;
-      if (en.isIntersecting){
-        Object.values(links).forEach(x => x.classList.remove('active'));
-        a.classList.add('active');
-      }
-    });
-  }, { rootMargin: '-60px 0px -55% 0px', threshold: 0 });
-  document.querySelectorAll('section[id]').forEach(sec => obs.observe(sec));
-}
-
-// =====================================================
-// 8. Client-side search across visible text
-// =====================================================
-function setupSearch(){
-  const input = document.getElementById('search');
-  let prevHits = [];
-  function clearHits(){
-    prevHits.forEach(node => {
-      const t = document.createTextNode(node.textContent);
-      node.parentNode.replaceChild(t, node);
-    });
-    prevHits = [];
-  }
-  function highlight(text){
-    if (!text){ clearHits(); return; }
-    clearHits();
-    const main = document.querySelector('.main');
-    const walker = document.createTreeWalker(main, NodeFilter.SHOW_TEXT, {
-      acceptNode(n){
-        if (!n.nodeValue.trim()) return NodeFilter.FILTER_REJECT;
-        if (n.parentElement.closest('script,style,template,mark')) return NodeFilter.FILTER_REJECT;
-        return NodeFilter.FILTER_ACCEPT;
-      }
-    });
-    const re = new RegExp('(' + text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ')', 'gi');
-    const todo = []; let n;
-    while ((n = walker.nextNode())){
-      if (n.nodeValue.match(re)) todo.push(n);
-    }
-    let first = null;
-    todo.forEach(node => {
-      const frag = document.createDocumentFragment();
-      const parts = node.nodeValue.split(re);
-      parts.forEach(p => {
-        if (re.test(p)){
-          const m = document.createElement('mark');
-          m.className = 'hit'; m.textContent = p;
-          frag.appendChild(m); prevHits.push(m); if (!first) first = m;
-        } else {
-          frag.appendChild(document.createTextNode(p));
-        }
-        re.lastIndex = 0;
-      });
-      node.parentNode.replaceChild(frag, node);
-    });
-    if (first){ first.scrollIntoView({behavior:'smooth', block:'center'}); }
-  }
-  let t;
-  input.addEventListener('input', () => {
-    clearTimeout(t);
-    t = setTimeout(() => highlight(input.value.trim()), 220);
-  });
-}
-
-// =====================================================
-// 9. Wolfram Cloud embed (per integration-contract states)
-//    States: Live (Public-Execute URL) | Private (uploaded, owner-only) |
-//    Pending (no URL provided yet)     | Failed (data-permission="failed"
-//                                       or "missing" — diagnostic-only,
-//                                       not shown to public viewers)
-// =====================================================
-function initWolframEmbeds(){
-  document.querySelectorAll('.wolfram-embed-wrap').forEach(el => {
-    const url = (el.dataset.cloudUrl || '').trim();
-    const name = el.dataset.notebookName || 'notebook';
-    const path = el.dataset.cloudPath || '';
-    const permissionRaw = (el.dataset.permission || '').trim();
-    const permission = permissionRaw.toLowerCase();
-    const isLocal = permission === 'local';
-    const isFailed = permission === 'failed' || permission === 'missing';
-    const isPrivate = permission === 'private' || url === 'PRIVATE';
-    const isPending = !isFailed && !isPrivate &&
-                      (!url || url === 'PENDING' ||
-                       url.startsWith('PLACEHOLDER') || !url.startsWith('http'));
-
-    if (isLocal){
-      el.innerHTML =
-        '<div class="wolfram-embed-status pending">' +
-          '<span class="dot"></span>' +
-          '<span class="label">Local notebook</span>' +
-          '<span>Detected locally; publish through <code>wolfram-cloud-sync</code> for an embeddable iframe</span>' +
-        '</div>' +
-        '<div class="wolfram-pending-body">' +
-          '<p><strong>' + escapeHTML(name) + '</strong> exists in this repo but does not yet have a Cloud embed URL.</p>' +
-          (path ? '<p>Local path: <code>' + escapeHTML(path) + '</code></p>' : '') +
-          '<p>Once uploaded with Public-Execute permission, this block becomes a live Wolfram iframe.</p>' +
-        '</div>';
-      return;
-    }
-    if (isFailed){
-      // Diagnostic state — shown to owner so the broken-link case is visible
-      el.innerHTML =
-        '<div class="wolfram-embed-status failed">' +
-          '<span class="dot"></span>' +
-          '<span class="label">Diagnostic — ' + permission + '</span>' +
-          '<span>Cloud sync ran into an error for this notebook. Re-run <code>wolfram-cloud-sync</code> publish.</span>' +
-        '</div>' +
-        '<div class="wolfram-pending-body">' +
-          '<p><strong>' + escapeHTML(name) + '</strong> permission state: <code>' + escapeHTML(permissionRaw) + '</code>.</p>' +
-          (path ? '<p>Cloud path: <code>' + escapeHTML(path) + '</code></p>' : '') +
-          '<p>This block is visible only to the repo owner; the public-facing site will hide it once published.</p>' +
-        '</div>';
-      return;
-    }
-    if (isPrivate){
-      el.innerHTML =
-        '<div class="wolfram-embed-status private">' +
-          '<span class="dot"></span>' +
-          '<span class="label">Owner-only — not yet published</span>' +
-          '<span>Uploaded; interactive embed appears once permission flips to Public-Execute</span>' +
-        '</div>' +
-        '<div class="wolfram-pending-body">' +
-          '<p><strong>' + escapeHTML(name) + '</strong> is uploaded to Wolfram Cloud but not publicly accessible yet.</p>' +
-          (path ? '<p>Cloud path: <code>' + escapeHTML(path) + '</code> (owner can open in Wolfram Cloud).</p>' : '') +
-          '<p>Public-Execute permission is granted on a per-instrument basis as each explorer matures and the release gates pass.</p>' +
-        '</div>';
-      return;
-    }
-    if (isPending){
-      el.innerHTML =
-        '<div class="wolfram-embed-status pending">' +
-          '<span class="dot"></span>' +
-          '<span class="label">Upload pending</span>' +
-          '<span>Awaiting <code>wolfram-cloud-sync</code> upload + public-execute permission</span>' +
-        '</div>' +
-        '<div class="wolfram-pending-body">' +
-          '<p><strong>' + escapeHTML(name) + '</strong> hasn\'t been published to Wolfram Cloud yet.</p>' +
-          (path ? '<p>Target cloud path: <code>' + escapeHTML(path) + '</code></p>' : '') +
-          '<p>Once the notebook is uploaded and set to public-execute, the live interactive embed will appear here.</p>' +
-        '</div>';
-      return;
-    }
-    // Live embed
-    el.innerHTML =
-      '<div class="wolfram-embed-status live">' +
-        '<span class="dot"></span>' +
-        '<span class="label">Live</span>' +
-        '<span>Interactive — runs in Wolfram Cloud</span>' +
-      '</div>' +
-      '<iframe class="wolfram-embed-iframe"' +
-        ' src="' + escapeHTML(url) + '"' +
-        ' title="' + escapeHTML(name) + ' — interactive Wolfram notebook"' +
-        ' sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"' +
-        ' allow="fullscreen"' +
-        ' loading="lazy"></iframe>';
-  });
-}
-
-// =====================================================
-// 10. CAD viewer — flip header to "live" when model loads
-// =====================================================
-function initCAD(){
-  const mv = document.getElementById('cad-mv');
-  const head = document.getElementById('cad-head');
-  if (!mv || !head) return;
-  mv.addEventListener('load', () => {
-    const label = mv.dataset.modelLabel || 'CAD model';
-    const src = mv.dataset.modelSrc || mv.getAttribute('src') || 'inline embedded GLB';
-    head.classList.add('live');
-    head.querySelector('.note').innerHTML =
-      'Loaded <code>' + escapeHTML(src) + '</code> — drag to orbit, scroll to zoom around ' + escapeHTML(label) + '.';
-  });
-  mv.addEventListener('error', () => {
-    head.querySelector('.note').innerHTML =
-      'CAD model could not be loaded — the most likely cause is opening from a local file URL. Serve the repo with a local web server, or check that the referenced <code>.glb/.gltf</code> asset exists.';
-  });
-}
-
-// =====================================================
-// 11. Boot
-// =====================================================
-function boot(){
-  initFiles();
-  buildTOC();
-  activeTOC();
-  setupSearch();
-  initWolframEmbeds();
-  initCAD();
-  injectCADModel();
-}
-
-// =====================================================
-// 12. Inject the inline glTF (DRACO-compressed .glb as a base64 data URI)
-//     Data URI itself lives in a separate <script id="instrument-glb-data"> tag
-//     near the top of the body so this IIFE can find it on boot.
-//     Encoded from the resolved instrument .glb when small enough to inline.
-// =====================================================
-function injectCADModel(){
-  const mv = document.querySelector('model-viewer[data-glb-uri-target="1"]');
-  if (!mv) return;
-  if (typeof window.__INSTRUMENT_GLB_DATA_URI__ === 'string' && window.__INSTRUMENT_GLB_DATA_URI__.length > 100){
-    mv.src = window.__INSTRUMENT_GLB_DATA_URI__;
-  }
-}
-
-if (document.readyState === 'loading'){
-  document.addEventListener('DOMContentLoaded', boot);
-} else { boot(); }
-
-})();
-</script>
-
+    <section class="panel">
+      <p class="meta">Packet artifacts</p>
+      <h2>Artifact list</h2>
+      <ul class="artifact-list">
+        <li>
+          <strong><a href="README.md">Packet README</a></strong><br>
+          <span class="meta">reference_only · packet_card · not_applicable</span><br>
+          Reader-facing summary and repo map.
+        </li>
+        <li>
+          <strong><a href="design.md">Design sheet</a></strong><br>
+          <span class="meta">fabrication · detail_link · not_applicable</span><br>
+          Governing acoustic model, parametric dimensions, and material assumptions.
+        </li>
+        <li>
+          <strong><a href="bom.csv">Bill of materials</a></strong><br>
+          <span class="meta">fabrication · detail_link · not_applicable</span><br>
+          Part list with quantities, materials, and estimated cost.
+        </li>
+        <li>
+          <strong><a href="validation.csv">Validation table</a></strong><br>
+          <span class="meta">reference_only · detail_link · not_applicable</span><br>
+          Predicted vs measured values; names remaining measurement gates.
+        </li>
+        <li>
+          <strong><a href="risks.md">Risk register</a></strong><br>
+          <span class="meta">reference_only · detail_link · not_applicable</span><br>
+          Acoustic, structural, ergonomic, supply, and fit/finish risks each with a verification test.
+        </li>
+        <li>
+          <strong><a href="photo-shotlist.md">Photo shot list</a></strong><br>
+          <span class="meta">reference_only · detail_link · not_applicable</span><br>
+          Required shots per build stage for build-log documentation.
+        </li>
+        <li>
+          <strong><a href="visual-output-register.csv">Visual output register</a></strong><br>
+          <span class="meta">reference_only · detail_link · not_applicable</span><br>
+          Records which artifacts are previews versus controlling geometry.
+        </li>
+        <li>
+          <strong><a href="https://www.wolframcloud.com/obj/wrfcoin/Musical_Instruments/percussion/djembe/djembe-goblet-acoustics.wl" target="_blank" rel="noopener">Wolfram model — djembe-goblet-acoustics.wl</a></strong><br>
+          <span class="meta">reference_only · runtime_note · source_only</span><br>
+          Acoustic physics source. Included as source-only evidence — no executed runtime output claimed.
+        </li>
+      </ul>
+    </section>
+  </main>
+  <footer>Instrument-Maker V5 export · djembe · 2026-06-21 · tonykoop/instrument-maker</footer>
 </body>
 </html>

--- a/explorer.html
+++ b/explorer.html
@@ -163,7 +163,14 @@
         </li>
       </ul>
     </section>
-  </main>
+  
+<section id="concept-images">
+  <h2>Concept Images</h2>
+  <figure><img src="images/hero-render.png" alt="Djembe — concept hero render" loading="lazy"></figure>
+  <figure><img src="images/macro/rope-tuning-weave.png" alt="Djembe — macro detail: rope tuning weave" loading="lazy"></figure>
+  <figure><img src="images/macro/stave-seams.png" alt="Djembe — macro detail: stave seams" loading="lazy"></figure>
+</section>
+</main>
   <footer>Instrument-Maker V5 export · djembe · 2026-06-21 · tonykoop/instrument-maker</footer>
 </body>
 </html>

--- a/sourcing.csv
+++ b/sourcing.csv
@@ -1,0 +1,6 @@
+part,description,qty,unit,supplier,part_number,unit_price_usd,lead_days,notes
+shell-stock,Hardwood shell stock (TBD species),TBD,board-ft,TBD,TBD,TBD,TBD,Per cut-list.csv
+head,Drum head (TBD diameter),1,each,TBD,TBD,TBD,14,Confirm fit with shell OD
+counter-hoop,Counter hoop (TBD diameter),1,each,TBD,TBD,TBD,14,Match head diameter
+tensioning-hardware,Tensioning hardware (TBD style),TBD,each,TBD,TBD,TBD,TBD,Rope / lug / rod per design.md
+finish,Wood finish (oil / wax / shellac),1,pint,TBD,TBD,TBD,3,Food-safe if skin contact

--- a/supplier-rfq.md
+++ b/supplier-rfq.md
@@ -1,0 +1,30 @@
+# Supplier RFQ — Djembe — Stave-Built Goblet Drum
+
+> **Status: placeholder** — populate with confirmed part numbers, quantities,
+> and quoted lead times before placing orders.
+
+## How to use this file
+
+Send relevant sections to suppliers; combine into a single email RFQ where the
+supplier handles multiple line items.  Record quote date and contact in the
+notes column of `sourcing.csv`.
+
+## Part Requests
+
+| Part | Specification | Qty | Target price | Notes |
+|------|---------------|-----|-------------|-------|
+| Head | TBD diameter, natural goatskin or synthetic | TBD | TBD | Confirm fit with shell OD |
+| Shell stock | TBD species, thickness, board-feet | TBD | TBD | Per cut-list.csv |
+| Tensioning hardware | TBD style (rope / lug / rod) | TBD | TBD | Per design.md |
+| Counter-hoop | TBD diameter, steel or wood | TBD | TBD | Match head OD |
+| Finish | TBD (oil / wax / shellac) | TBD | TBD | Food-safe if skin contact |
+
+## Preferred Suppliers
+
+*(Populate from `sourcing.csv` when confirmed)*
+
+## Lead-Time Notes
+
+- Natural-skin heads: 2–4 weeks if not in stock; order first.
+- Hardwood shell stock: check Woodcraft / Hearne Hardwoods / local sawmill.
+- Hardware: check Remo / LP / Toca for drum hardware; hardware stores for rod stock.

--- a/visual-bom-brief.md
+++ b/visual-bom-brief.md
@@ -1,0 +1,34 @@
+# Visual BOM Brief — Djembe — Stave-Built Goblet Drum
+
+> **Status: placeholder** — replace rendered placeholder images with actual
+> build photos at L3 promotion.
+
+## Purpose
+
+This brief defines the visual-BOM assembly image requirements: one hero render
+or photo per major assembly and one close-up per critical joint or hardware
+detail.
+
+## Hero Assembly Image
+
+- **Required:** one full instrument view showing finished assembly.
+- **Current status:** AI-generated concept render (non-dimensional authority).
+- **Acceptance:** replace with a photograph of the first finished prototype.
+
+## Part-Level Images
+
+| Part | Image required | Authority | Notes |
+|------|---------------|-----------|-------|
+| Shell / body | Yes | concept only | Show stave pattern or sheet metal form |
+| Head + hoop | Yes | concept only | Show tensioning hardware |
+| Hardware detail | Yes | concept only | Lug / rope / rod close-up |
+| Finished instrument | Yes | prototype photo | Primary visual BOM entry |
+
+## Image Conventions
+
+- Shoot on a neutral background (white or grey paper sweep).
+- Include a scale reference (rule or known object) in at least one shot.
+- Label files: `djembe-[part]-[sequence].jpg` (e.g., `djembe-shell-01.jpg`).
+- Record each image in `visual-output-register.csv` with its authority label.
+
+*See `photo-shotlist.md` for the shot list tied to build stages.*

--- a/wolfram/djembe-goblet-acoustics.wl
+++ b/wolfram/djembe-goblet-acoustics.wl
@@ -1,0 +1,94 @@
+(* Djembe Goblet Drum — Parametric Cavity Acoustics Starter
+   tonykoop/djembe
+   Authority: estimate placeholders only.
+   Goblet profiles from CAD/djembe-body/parametric-goblet.csv (Morgan S/M/L).
+   Manipulate block is CloudDeploy-ready (Public-Execute). *)
+
+(* ── Lumped Helmholtz resonator model ──
+   f_H = (c / (2π)) * Sqrt[S / (V * L_eff)]
+   where S = neck cross-section area, V = bowl volume, L_eff = effective neck length.
+   See analysis/helmholtz-fem/ for the 1D Webster FEM that refines these estimates. *)
+
+HelmholtzFreq[S_Real, V_Real, Leff_Real, c_Real : 343.0] :=
+  (c / (2 Pi)) * Sqrt[S / (V * Leff)]
+
+(* Convert inches³ → m³ *)
+In3ToM3[x_Real] := x * 0.0000163871
+
+(* Convert inches² → m² *)
+In2ToM2[x_Real] := x * 0.00064516
+
+(* Convert inches → m *)
+InToM[x_Real] := x * 0.0254
+
+(* Morgan profiles from parametric-goblet.csv *)
+MorganProfiles = {
+  <|"label" -> "Morgan-9 (S)", "head_in" -> 9.0, "neck_dia_in" -> 5.0,
+    "foot_in" -> 8.0, "height_in" -> 18.0,
+    "S_in2" -> 19.635, "Leff_in" -> 6.25, "V_in3" -> 603.2|>,
+  <|"label" -> "Morgan-10 (M)", "head_in" -> 10.0, "neck_dia_in" -> 5.5,
+    "foot_in" -> 8.5, "height_in" -> 20.0,
+    "S_in2" -> 23.758, "Leff_in" -> 6.675, "V_in3" -> 794.8|>,
+  <|"label" -> "Morgan-12 (L)", "head_in" -> 12.0, "neck_dia_in" -> 6.5,
+    "foot_in" -> 10.0, "height_in" -> 24.0,
+    "S_in2" -> 33.183, "Leff_in" -> 8.025, "V_in3" -> 1400.5|>
+};
+
+(* Print reference table *)
+TableForm[
+  Table[
+    Module[{p = MorganProfiles[[i]]},
+      {
+        p["label"],
+        NumberForm[p["head_in"], {4, 1}],
+        NumberForm[p["height_in"], {4, 1}],
+        NumberForm[
+          HelmholtzFreq[
+            In2ToM2[p["S_in2"]],
+            In3ToM3[p["V_in3"]],
+            InToM[p["Leff_in"]]
+          ], {5, 1}
+        ]
+      }
+    ],
+    {i, 1, 3}
+  ],
+  TableHeadings -> {
+    None,
+    {"Profile", "Head diam (in)", "Height (in)", "Lumped f_H (Hz)"}
+  }
+]
+
+(* ── Interactive Manipulate ── *)
+
+Manipulate[
+  Module[
+    {
+      (* Convert user sliders to SI *)
+      S_m2   = In2ToM2[N[Pi * (neckDia_in / 2)^2]],
+      Leff_m = InToM[leff_in],
+      V_m3   = In3ToM3[bowl_in3],
+      fH     = HelmholtzFreq[In2ToM2[N[Pi * (neckDia_in / 2)^2]], In3ToM3[bowl_in3], InToM[leff_in]]
+    },
+    Grid[{
+      {"Head diameter (in)", NumberForm[headDia_in, {4, 1}]},
+      {"Neck diameter (in)", NumberForm[neckDia_in, {4, 1}]},
+      {"Neck effective length (in)", NumberForm[leff_in, {4, 2}]},
+      {"Bowl volume (in³)", NumberForm[bowl_in3, {5, 0}]},
+      {"Neck S (in²)", NumberForm[N[Pi * (neckDia_in / 2)^2], {4, 2}]},
+      {"Lumped Helmholtz f₀ (Hz)", NumberForm[fH, {5, 1}]},
+      {"Notes", "L1 estimate; FEM in analysis/ refines this."}
+    },
+    Frame -> All,
+    Background -> {{GrayLevel[0.88], White}, None}]
+  ],
+
+  (* Controls *)
+  {{headDia_in, 10.0, "Head diameter (in)"}, 8.0, 14.0, 0.5, Appearance -> "Labeled"},
+  {{neckDia_in, 5.5, "Neck diameter (in)"}, 3.5, 8.0, 0.25, Appearance -> "Labeled"},
+  {{leff_in, 6.5, "Eff. neck length (in)"}, 3.0, 12.0, 0.25, Appearance -> "Labeled"},
+  {{bowl_in3, 700.0, "Bowl volume (in³)"}, 100.0, 1600.0, 10.0, Appearance -> "Labeled"},
+
+  ControlPlacement -> Left,
+  TrackedSymbols :> {headDia_in, neckDia_in, leff_in, bowl_in3}
+]


### PR DESCRIPTION
## Summary

- **explorer.html** replaced with V5 parchment-card format: readiness chip, authority-split chip, family chip, per-artifact authority badges (fabrication / derived_preview / reference_only / source_only), and link to `data/deliverables-export.json`
- **data/deliverables-export.json** added — machine-readable V5 manifest for instrument-showcase handoff
- **Missing build-packet stubs** added where absent (drawing-brief.md, assembly-manual.md, supplier-rfq.md, visual-bom-brief.md, photo-shotlist.md, sourcing.csv, cut-list.csv, cnc/setup-sheet.md) as TBD-ready placeholders per v4.5 standard

Refs instrument-maker v4.5 · V5 export card standard · DXF-first visual authority guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)