### PR TITLE
chore: gitignore CAD build-artifact + render-scratch hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,41 @@ desktop.ini
 abaqus_acis.log
 # Stash-recovery sidecars
 stash-recovered-*/
+
+# --- Standard maker/CAD hygiene (added per instrument-maker #195) ---
+# OS cruft
+.DS_Store
+Thumbs.db
+Desktop.ini
+
+# Editor/swap files
+*.swp
+*.swo
+*~
+.vscode/
+.idea/
+
+# CAD backup/lock/temp exports (not final deliverables)
+~$*
+*.SLDPRT~
+*.SLDASM~
+*.SLDDRW~
+*.stl.tmp
+*.3mf.tmp
+*.step.tmp
+*.f3d.lock
+*.f3z.lock
+*.sldprt.lock
+*.sldasm.lock
+*.slddrw.lock
+
+# OpenSCAD temp/cache
+*.scad.bak
+.openscad_cache/
+
+# Render/export scratch (not committed deliverables)
+renders/tmp/
+renders/scratch/
+exports/tmp/
+exports/scratch/
+scratch/


### PR DESCRIPTION
Adds the standard maker/CAD `.gitignore` stanza (OS cruft, editor swap files, CAD backup/lock/temp exports, OpenSCAD temp, render/export scratch dirs) that most instrument-maker repos already carry — this repo's `.gitignore` lacked it.

Mechanical, additive-only change; no existing lines removed.

Refs tonykoop/instrument-maker#195