### PR TITLE
chore: add .gitattributes for CRLF/binary hygiene

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,42 @@
+# Normalize all text to LF in the repo; nothing should depend on platform CRLF.
+* text=auto eol=lf
+
+# Explicit LF for code / docs / config
+*.py    text eol=lf
+*.pyi   text eol=lf
+*.toml  text eol=lf
+*.cfg   text eol=lf
+*.ini   text eol=lf
+*.md    text eol=lf
+*.txt   text eol=lf
+*.rst   text eol=lf
+*.json  text eol=lf
+*.yaml  text eol=lf
+*.yml   text eol=lf
+*.sh    text eol=lf
+*.csv   text eol=lf
+*.wl    text eol=lf
+LICENSE text eol=lf
+
+# Binary / never-normalize artifacts (present or future)
+*.png    binary
+*.jpg    binary
+*.jpeg   binary
+*.webp   binary
+*.gif    binary
+*.pdf    binary
+*.step   binary
+*.stp    binary
+*.stl    binary
+*.3mf    binary
+*.glb    binary
+*.gltf   binary
+*.obj    binary
+*.fcstd  binary
+*.dxf    binary
+*.SLDPRT binary
+*.SLDASM binary
+*.SLDDRW binary
+*.xlsx   binary
+*.docx   binary
+*.zip    binary


### PR DESCRIPTION
Adds the standard maker/CAD `.gitattributes` template (`text=auto eol=lf`, explicit LF for code/docs/config, binary excludes for CAD/image/office formats) — this repo had none, exposing it to CRLF drift when edited by both Windows tools and WSL.

Additive only; does **not** renormalize existing tracked blobs (`git add --renormalize`) — that's a deliberate separate follow-up so this PR doesn't produce a surprise mass line-ending diff.

Refs tonykoop/instrument-maker#215